### PR TITLE
Add timeout to SSE

### DIFF
--- a/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSourceListener.kt
+++ b/okhttp-sse/src/main/kotlin/okhttp3/sse/EventSourceListener.kt
@@ -19,6 +19,11 @@ import okhttp3.Response
 
 abstract class EventSourceListener {
   /**
+   * Milliseconds elapsed between 2 events until connection failed. Doesn't timeout if null
+   */
+  open var idleTimeoutMillis: Long? = null
+
+  /**
    * Invoked when an event source has been accepted by the remote peer and may begin transmitting
    * events.
    */


### PR DESCRIPTION
This PR adds the possibility to timeout the SSE connection. It is now possible to fail as soon as an event-free timeout is not reached, making it easier to detect a lost connection.

For a real world example: I've an app connected to a server. It sends a ping at a keepalive interval. I've a job checking from time to time that everything works as expected (using a worker, so the period is 15min, the minimum). It happens that the connection is lost at the beginning of this interval, therefore the users are disconnected for several minutes.

With this PR we can directly catch a lost connection: https://codeberg.org/NextPush/nextpush-android/commit/f6edb178ddee8255e9de6e548ea75f5d3eb6b32a

PS: I've also added some comments, but I can remove this commit from the branch