### PR TITLE
Change Gradle version from 9.0.0 to 8.14.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Gradle 9.0.0 is not supported by the Android Gradle Plugin (AGP), and attempting to use it tends to cause various build breakages caused by deprecated Gradle methods going away. AGP works with Gradle 8.x, though.

See also: https://developer.android.com/build/releases/gradle-plugin#updating-gradle

The reason why the breakage is not obvious is because when using Android Studio it will ignore this file and just use its bundled Gradle version. But that is not true in other cases, such as when using the VS Code Gradle extension.