### PR TITLE
Remove Thrifty from "works with OkHttp"

### DIFF
--- a/docs/works_with_okhttp.md
+++ b/docs/works_with_okhttp.md
@@ -35,5 +35,4 @@ Here’s some libraries that work nicely with OkHttp.
  * ⬜️ [Retrofit](https://github.com/square/retrofit): Type-safe HTTP client for Android and Java by Square.
  * [ScribeJava](https://github.com/scribejava/scribejava): Simple OAuth library for Java
  * [Stetho](https://github.com/facebook/stetho): Stetho is a debug bridge for Android applications.
- * [Thrifty](https://github.com/Microsoft/thrifty): An implementation of Apache Thrift for Android.
  * ⬜️ [Wire](https://github.com/square/wire): Clean, lightweight protocol buffers for Android and Java.


### PR DESCRIPTION
It is unclear why Thrifty is in this list: it doesn't use OkHttp, and a Google search for "Thrifty OkHttp" doesn't seem to return any relevant result.