### PR TITLE
reject SETTINGS_HEADER_TABLE_SIZE larger than 2^31 - 1

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Reader.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Http2Reader.kt
@@ -266,6 +266,9 @@ class Http2Reader(
       when (id) {
         // SETTINGS_HEADER_TABLE_SIZE
         1 -> {
+          if (value < 0) {
+            throw IOException("PROTOCOL_ERROR SETTINGS_HEADER_TABLE_SIZE > 2^31 - 1")
+          }
         }
 
         // SETTINGS_ENABLE_PUSH

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2Test.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/Http2Test.kt
@@ -348,6 +348,22 @@ class Http2Test {
     )
   }
 
+  @Test fun readSettingsFrameNegativeHeaderTableSize() {
+    writeMedium(frame, 6) // 2 for the code and 4 for the value
+    frame.writeByte(Http2.TYPE_SETTINGS)
+    frame.writeByte(FLAG_NONE)
+    frame.writeInt(0) // Settings are always on the connection stream 0.
+    frame.writeShort(1) // SETTINGS_HEADER_TABLE_SIZE
+    frame.writeInt(Int.MIN_VALUE)
+    assertFailsWith<IOException> {
+      reader.nextFrame(requireSettings = false, BaseTestHandler())
+    }.also { expected ->
+      assertThat(expected.message).isEqualTo(
+        "PROTOCOL_ERROR SETTINGS_HEADER_TABLE_SIZE > 2^31 - 1",
+      )
+    }
+  }
+
   @Test fun readSettingsFrameNegativeWindowSize() {
     writeMedium(frame, 6) // 2 for the code and 4 for the value
     frame.writeByte(Http2.TYPE_SETTINGS)


### PR DESCRIPTION
readSettings decodes each SETTINGS value with a signed readInt(), and the size-shaped settings are meant to be range checked right where they're read. SETTINGS_INITIAL_WINDOW_SIZE and SETTINGS_MAX_FRAME_SIZE both reject a value whose high bit is set, but the SETTINGS_HEADER_TABLE_SIZE branch is empty, so a peer that advertises a header table size of 2^31 or more lands a negative int in the Settings. That value clears the != -1 guard in Http2Writer.applyAndAckSettings and reaches hpackWriter.resizeHeaderTable, where minOf(negative, 16384) stays negative and maxDynamicTableByteCount goes negative with it; adjustDynamicTableByteCount then runs evictToRecoverBytes against an empty dynamic table and walks off the end into a null slot, so the write side throws NullPointerException rather than a protocol error and the encoder's byte accounting is left broken. I noticed it lining up which settings check their value against which don't. Rejecting a negative header table size in the reader, the same way the two neighboring settings already do, keeps the bad value out of the encoder, and valid sizes decode unchanged since okhttp caps its own table at 16 KiB regardless.
