### PR TITLE
Set publish workflow JDK version inline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version-file: .github/workflows/.java-version
+          java-version: 21
 
       - run: ./gradlew publish
         env:


### PR DESCRIPTION
publish.yml points at a .java-version file that does not exist, so tag publishes fail at setup-java. 

Fixes #9547.