### PR TITLE
downgrade a public-suffix Domain cookie to host-only

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cookie.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cookie.kt
@@ -556,17 +556,19 @@ class Cookie private constructor(
       val urlHost = url.host
       if (domain == null) {
         domain = urlHost
-      } else if (!domainMatch(urlHost, domain)) {
-        return null // No domain match? This is either incompetence or malice!
-      }
-
-      // A public suffix can't be used as a cookie domain. If it's the request host itself the
-      // cookie is downgraded to host-only; if it's a proper suffix of the host it's refused.
-      if (PublicSuffixDatabase.get().getEffectiveTldPlusOne(domain) == null) {
-        if (urlHost.length != domain.length) {
-          return null
+      } else {
+        if (!domainMatch(urlHost, domain)) {
+          return null // No domain match? This is either incompetence or malice!
         }
-        hostOnly = true
+
+        // A public suffix can't be used as a cookie domain. If it's the request host itself the
+        // cookie is downgraded to host-only; if it's a proper suffix of the host it's refused.
+        if (PublicSuffixDatabase.get().getEffectiveTldPlusOne(domain) == null) {
+          if (urlHost.length != domain.length) {
+            return null
+          }
+          hostOnly = true
+        }
       }
 
       // If the path is absent or didn't start with '/', use the default path. It's a string like

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cookie.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/Cookie.kt
@@ -560,11 +560,13 @@ class Cookie private constructor(
         return null // No domain match? This is either incompetence or malice!
       }
 
-      // If the domain is a suffix of the url host, it must not be a public suffix.
-      if (urlHost.length != domain.length &&
-        PublicSuffixDatabase.get().getEffectiveTldPlusOne(domain) == null
-      ) {
-        return null
+      // A public suffix can't be used as a cookie domain. If it's the request host itself the
+      // cookie is downgraded to host-only; if it's a proper suffix of the host it's refused.
+      if (PublicSuffixDatabase.get().getEffectiveTldPlusOne(domain) == null) {
+        if (urlHost.length != domain.length) {
+          return null
+        }
+        hostOnly = true
       }
 
       // If the path is absent or didn't start with '/', use the default path. It's a string like

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CookieTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CookieTest.kt
@@ -323,6 +323,17 @@ class CookieTest {
     assertThat(parse(punycode, "a=b; domain=xn--8ltr62k.jp")).isNull()
   }
 
+  @Test fun domainEqualToRequestHostThatIsPublicSuffixIsHostOnly() {
+    val url = "https://github.io/".toHttpUrl()
+    val cookie = parse(url, "a=b; domain=github.io")
+    assertThat(cookie).isNotNull()
+    assertThat(cookie!!.hostOnly).isTrue()
+    assertThat(cookie.domain).isEqualTo("github.io")
+    // The cookie stays with the request host and doesn't leak to other hosts under the suffix.
+    assertThat(cookie.matches("https://victim.github.io/".toHttpUrl())).isFalse()
+    assertThat(cookie.matches(url)).isTrue()
+  }
+
   @Test fun hostOnly() {
     assertThat(parse(url, "a=b")!!.hostOnly).isTrue()
     assertThat(


### PR DESCRIPTION
When a Set-Cookie header carries a Domain attribute, Cookie.parse checks that the domain isn't a public suffix, so a server can't scope a cookie to something like `github.io` or a `*.elb.amazonaws.com` label and have it ride along to every host underneath. The problem is that the check is gated on `urlHost.length != domain.length`, so it only runs when the Domain is a proper suffix of the request host and is skipped whenever the Domain equals the host exactly. A response from a host that is itself a public suffix slips right through: `https://github.io/` returning `Set-Cookie: a=b; Domain=github.io` never reaches the public-suffix lookup, hostOnly stays false, and the cookie then matches every `*.github.io` host in `Cookie.matches`. RFC 6265 section 5.3 covers this exact case by turning the cookie into a host-only cookie rather than a shared domain cookie. I ran into it reading the length comparison next to the existing `domainIsPublicSuffix` test, which only walks the proper-suffix path and never the equal-length one. The fix runs the public-suffix lookup whenever a Domain is present, still refuses a proper-suffix public suffix as before, and marks the cookie host-only when the domain equals the host; registrable domains like example.com are untouched because their eTLD+1 is non-null.
