### PR TITLE
fix: throw UnknownHostException for unsuccessful HTTP responses in DnsOverHttps [FaaFyfxR9WAQrL7FcAgEHJvztd8cVMxvjHRS55rw1nwH]

### DIFF
--- a/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsOverHttpsQuery.kt
+++ b/okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsOverHttpsQuery.kt
@@ -181,7 +181,7 @@ internal fun decodeResponse(response: Response): DnsMessage {
 
   response.use {
     if (!response.isSuccessful) {
-      throw IOException("response: ${response.code} ${response.message}")
+      throw UnknownHostException("response: ${response.code} ${response.message}")
     }
 
     val body = response.body


### PR DESCRIPTION
## Fixes #9698

### Problem

`DnsOverHttps` (via `DnsOverHttpsQuery.decodeResponse`) throws a raw `IOException` when the DNS-over-HTTPS server returns an unsuccessful HTTP response (e.g. HTTP 429 or 500):

```kotlin
if (!response.isSuccessful) {
  throw IOException("response: ${response.code} ${response.message}")
}
```

This is inconsistent with every other `Dns` implementation in OkHttp, which report resolution failures as `UnknownHostException` (see `StateMachineDnsCall.updateStateAndCallCallbacks`, which also throws `UnknownHostException` for `RESPONSE_CODE_SERVER_FAILURE` and other error codes). Callers that catch `UnknownHostException` to handle DNS failures — as recommended by the `Dns.lookup` contract — silently miss this error.

### Root cause

`decodeResponse` uses `IOException` instead of `UnknownHostException` for the non-2xx HTTP path. Since `UnknownHostException` extends `IOException`, the fix is a drop-in replacement with no behavioral change for existing `IOException` catch blocks.

### Fix

Change the throw type in `okhttp-dnsoverhttps/src/main/kotlin/okhttp3/dnsoverhttps/internal/-DnsOverHttpsQuery.kt`:

```kotlin
// Before
throw IOException("response: ${response.code} ${response.message}")

// After
throw UnknownHostException("response: ${response.code} ${response.message}")
```

`UnknownHostException` is already imported in this file.

### Verification

The existing test suite covers the unchanged paths:
- `failOnExcessiveResponse` — still throws `IOException` (via `ProtocolException`) for oversized bodies
- `failOnBadResponse` — still throws `IOException` (via `EOFException`) for malformed DNS payloads
- `httpsFailureIsDeliveredAfterIpv6AndIpv4Records` — error delivery ordering unchanged

Both `IOException`-based cases remain `IOException` because they're protocol/parse failures, not resolution failures. Only the HTTP error path (a server-side resolution failure) now surfaces as `UnknownHostException`, matching the behavior of `Dns.SYSTEM` and the DNS-over-UDP state machine.
