### PR TITLE
fix: reject CRLF in quoted MediaType parameters to prevent CRLF injection

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/MediaType.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/MediaType.kt
@@ -91,7 +91,7 @@ class MediaType internal constructor(
 
   companion object {
     private const val TOKEN = "([a-zA-Z0-9-!#$%&'*+.^_`{|}~]+)"
-    private const val QUOTED = "\"([^\"]*)\""
+    private const val QUOTED = "\"([^\"\\r\\n]*)\""
     private val TYPE_SUBTYPE = Regex("$TOKEN/$TOKEN")
     private val PARAMETER = Regex(";\\s*(?:$TOKEN=(?:$TOKEN|$QUOTED))?")
 

--- a/okhttp/src/jvmTest/kotlin/okhttp3/MediaTypeTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/MediaTypeTest.kt
@@ -124,6 +124,22 @@ open class MediaTypeTest {
       "text/plain ; a=1",
       "Parameter is not formatted correctly: \" ; a=1\" for: \"text/plain ; a=1\"",
     )
+    assertInvalid(
+      "text/plain; charset=\"a\rb\"",
+      "CR in quoted parameter is rejected",
+    )
+    assertInvalid(
+      "text/plain; charset=\"a\nb\"",
+      "LF in quoted parameter is rejected",
+    )
+    assertInvalid(
+      "text/plain; charset=\"a\r\nb\"",
+      "CRLF in quoted parameter is rejected",
+    )
+    assertInvalid(
+      "text/plain; boundary=\"a\r\nb\"",
+      "CRLF in quoted boundary is rejected",
+    )
   }
 
   @Test fun testDoubleQuotesAreSpecial() {


### PR DESCRIPTION
Fixes #9725

## Problem

`MediaType` accepts CR and LF inside a quoted parameter value, while `MultipartBody` writes that media type directly into the part header without sanitisation. A content type taken from untrusted input can end the header block and append new multipart parts.

## Root cause

The `QUOTED` regex `"([^"]*)"` matches any characters between quotes, including `\r` and `\n`. The `PARAMETER` regex uses `QUOTED` as a sub-expression, so quoted parameter values containing CR/LF are accepted and stored verbatim.

## Fix

Change the `QUOTED` regex to exclude `\r` and `\n` from the character class:

```kotlin
private const val QUOTED = "\"([^\"\\r\\n]*)\""
```

This makes `toMediaType()` throw `IllegalArgumentException` for any media type string with CR/LF in quoted parameter values, and `toMediaTypeOrNull()` returns `null`. Since `MultipartBody` can only obtain a `MediaType` through the public parsing API, the injection path is closed at the root.

## Verification

All existing tests pass. Added 4 regression tests to `MediaTypeTest.testInvalidParse()` confirming CR, LF, CRLF in quoted `charset` and `boundary` parameter values are rejected.
