### PR TITLE
require three ASCII digits for the response status code

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/StatusLine.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/StatusLine.kt
@@ -73,15 +73,15 @@ class StatusLine(
         throw ProtocolException("Unexpected status line: $statusLine")
       }
 
-      // Parse response code like "200". Always 3 digits.
+      // Parse response code like "200". Always 3 ASCII digits.
       if (statusLine.length < codeStart + 3) {
         throw ProtocolException("Unexpected status line: $statusLine")
       }
-      val code =
-        statusLine.substring(codeStart, codeStart + 3).toIntOrNull()
-          ?: throw ProtocolException(
-            "Unexpected status line: $statusLine",
-          )
+      val codeString = statusLine.substring(codeStart, codeStart + 3)
+      if (!codeString.all { it in '0'..'9' }) {
+        throw ProtocolException("Unexpected status line: $statusLine")
+      }
+      val code = codeString.toInt()
 
       // Parse an optional response message like "OK" or "Not Modified". If it
       // exists, it is separated from the response code by a space.

--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/StatusLine.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http/StatusLine.kt
@@ -77,11 +77,14 @@ class StatusLine(
       if (statusLine.length < codeStart + 3) {
         throw ProtocolException("Unexpected status line: $statusLine")
       }
-      val codeString = statusLine.substring(codeStart, codeStart + 3)
-      if (!codeString.all { it in '0'..'9' }) {
-        throw ProtocolException("Unexpected status line: $statusLine")
+      var code = 0
+      for (i in codeStart until codeStart + 3) {
+        val digit = statusLine[i]
+        if (digit !in '0'..'9') {
+          throw ProtocolException("Unexpected status line: $statusLine")
+        }
+        code = code * 10 + (digit - '0')
       }
-      val code = codeString.toInt()
 
       // Parse an optional response message like "OK" or "Not Modified". If it
       // exists, it is separated from the response code by a space.

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http/StatusLineTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http/StatusLineTest.kt
@@ -100,6 +100,16 @@ class StatusLineTest {
   }
 
   @Test
+  fun nonAsciiDigitCode() {
+    // toIntOrNull() honors a sign prefix and any Unicode decimal digit, so a status code such
+    // as "+99", "-12" or the Arabic-Indic "٢٠٠" would otherwise be accepted even though
+    // RFC 9112 defines status-code as three ASCII DIGIT.
+    assertInvalid("HTTP/1.1 +99 OK")
+    assertInvalid("HTTP/1.1 -12 OK")
+    assertInvalid("HTTP/1.1 ٢٠٠ OK")
+  }
+
+  @Test
   fun truncated() {
     assertInvalid("")
     assertInvalid("H")


### PR DESCRIPTION
StatusLine.parse pulls the three response-code characters out of the status line and hands them to toIntOrNull() to get the numeric code. That delegate does more than read ASCII digits: it accepts a leading + or - sign, and because it resolves each character through Character.digit it also accepts any Unicode decimal digit, so an Arabic-Indic "٢٠٠" comes back as 200 and "+99" as 99. RFC 9112 defines status-code as exactly three ASCII DIGIT, and the value here comes straight off the wire, whether from an HTTP/1 status line, an HTTP/2 :status pseudo-header (Http2ExchangeCodec builds "HTTP/1.1 $value" from it), or a cached response, so a hostile or non-conforming server can hand okhttp a code that a conforming proxy or log sitting in front of it reads differently. A "-12" even parses to a negative code that only trips a check much later when the Response is built. I noticed it while adding cases to the existing nonThreeDigitCode test, which only covered letters and wrong lengths. Restricting the three characters to '0'..'9' before converting keeps every valid code working and rejects the rest at the parser.
