### PR TITLE
Count HPACK header list entries with RFC 9113 per-entry overhead

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Hpack.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/internal/http2/Hpack.kt
@@ -47,6 +47,11 @@ object Hpack {
   private const val PREFIX_6_BITS = 0x3f
   private const val PREFIX_7_BITS = 0x7f
 
+  /**
+   * Per-entry overhead of a header list entry, as defined by RFC 9113 section 6.5.2.
+   */
+  private const val HEADER_ENTRY_OVERHEAD = 32
+
   private const val SETTINGS_HEADER_TABLE_SIZE = 4_096
 
   /**
@@ -411,7 +416,9 @@ object Hpack {
       private fun addHeader(header: Header) {
         headerList.add(header)
 
-        val headerSize = header.name.size + header.value.size
+        // Include the per-entry overhead of RFC 9113 section 6.5.2, so the accounting
+        // also grows for headers whose name and value are both empty.
+        val headerSize = header.name.size + header.value.size + HEADER_ENTRY_OVERHEAD
         val newHeaderListSize = headerListByteCount + headerSize
         headerListByteCount = newHeaderListSize
         if (newHeaderListSize > HEADER_LIMIT) {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HpackTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/internal/http2/HpackTest.kt
@@ -36,6 +36,24 @@ class HpackTest {
   private val bytesOut = Buffer()
   private var hpackWriter: Hpack.Writer? = null
 
+  /**
+   * Each header list entry must account for the RFC 9113 section 6.5.2 per-entry overhead,
+   * including headers whose name and value are both empty. Otherwise a peer could flood
+   * zero-length literal header fields and grow the header list without ever exceeding
+   * [HEADER_LIMIT].
+   */
+  @Test
+  fun manyEmptyHeadersExceedByteLimit() {
+    repeat(8193) {
+      bytesIn.writeByte(0x00) // Literal Header Field without Indexing, new name.
+      bytesIn.writeByte(0x00) // Name length 0.
+      bytesIn.writeByte(0x00) // Value length 0.
+    }
+    assertFailsWith<IOException> {
+      hpackReader!!.readHeaders()
+    }
+  }
+
   @BeforeEach
   fun reset() {
     hpackReader = newReader(bytesIn)


### PR DESCRIPTION
## Problem
The header list byte limit in `Hpack.Reader` was computed as `name.size + value.size`, so a literal header field whose name and value are both empty contributed **zero** bytes to the accounting:

```
00 00 00   // Literal Header Field without Indexing, name length 0, value length 0
```

A peer can send HEADERS/CONTINUATION frames (not flow controlled) composed of these 3-byte entries and grow the header list indefinitely — one `Header` object per 3 wire bytes, roughly 30-50x heap amplification — without the 256 KiB `HEADER_LIMIT` ever being exceeded. `MAX_HEADER_LIST_SIZE` is not enforced ("Advisory only" in `Http2Reader`), so this is the only cap. This is the same class of issue as CVE-2024-27316 (nghttp2 CONTINUATION flood).

## Fix
Account for the 32-byte per-entry overhead defined by [RFC 9113 §6.5.2](https://www.rfc-editor.org/rfc/rfc9113.html#section-6.5.2) when a header is added, matching nghttp2 and Jetty. Every header entry now consumes budget regardless of name/value length, so zero-length entries cannot bypass the limit.

## Test
`manyEmptyHeadersExceedByteLimit` — sends 8193 zero-length literal headers (24 KiB) and expects the reader to throw. Fails on `master` (no exception — the limit never trips) and passes with this change. Full `HpackTest` suite (58 tests) passes.