### PR TITLE
Normalize trailing dot when matching hostnames against certificate pins

### DIFF
--- a/okhttp/src/commonJvmAndroid/kotlin/okhttp3/CertificatePinner.kt
+++ b/okhttp/src/commonJvmAndroid/kotlin/okhttp3/CertificatePinner.kt
@@ -290,8 +290,14 @@ class CertificatePinner internal constructor(
       }
     }
 
-    fun matchesHostname(hostname: String): Boolean =
-      when {
+    fun matchesHostname(hostname: String): Boolean {
+      // A hostname may carry a trailing dot for an absolute DNS name -- ConnectPlan derives it
+      // from address.url.host, which explicitly preserves one. A pin's pattern is
+      // developer-authored and never has one, so without this normalization the pin is silently
+      // skipped against the dotted spelling of an otherwise-identical hostname.
+      // OkHostnameVerifier already treats both spellings as equivalent for the same reason.
+      val hostname = if (hostname.endsWith(".")) hostname.dropLast(1) else hostname
+      return when {
         pattern.startsWith("**.") -> {
           // With ** empty prefixes match so exclude the dot from regionMatches().
           val suffixLength = pattern.length - 3
@@ -312,6 +318,7 @@ class CertificatePinner internal constructor(
           hostname == pattern
         }
       }
+    }
 
     fun matchesCertificate(certificate: X509Certificate): Boolean =
       when (hashAlgorithm) {

--- a/okhttp/src/jvmTest/kotlin/okhttp3/CertificatePinnerKotlinTest.kt
+++ b/okhttp/src/jvmTest/kotlin/okhttp3/CertificatePinnerKotlinTest.kt
@@ -180,6 +180,23 @@ class CertificatePinnerKotlinTest {
     assertFalse(pin.matchesHostname("www.example.com"))
   }
 
+  @Test fun testMatchesHostnameWithTrailingDot() {
+    // https://github.com/lysine-dev/okhttp/issues/9724
+    val exactPin = Pin("example.com", certA1Sha256Pin)
+    assertTrue(exactPin.matchesHostname("example.com"))
+    assertTrue(exactPin.matchesHostname("example.com."))
+
+    val wildcardPin = Pin("*.example.com", certA1Sha256Pin)
+    assertTrue(wildcardPin.matchesHostname("a.example.com"))
+    assertTrue(wildcardPin.matchesHostname("a.example.com."))
+
+    val certificatePinner =
+      CertificatePinner.Builder()
+        .add("example.com", certA1Sha256Pin)
+        .build()
+    assertThat(certificatePinner.findMatchingPins("example.com.")).containsExactly(exactPin)
+  }
+
   @Test fun testMatchesSha256() {
     val pin = Pin("example.com", certA1Sha256Pin)
     assertTrue(pin.matchesCertificate(certA1.certificate))


### PR DESCRIPTION
﻿Fixes #9724.

Credit to Joshua Rogers (MegaManSec) for finding and reporting this, with a clear write-up and working PoC in the issue.

CertificatePinner.Pin.matchesHostname() compares hostname against pattern with plain string equality (or region matching for wildcard patterns), with no normalization of either side. hostname comes from address.url.host in ConnectPlan, which explicitly preserves a trailing dot for an absolute DNS name. A pin's pattern is developer-authored config and never has one. So a pin for example.com provides no protection at all against a connection to example.com. -- same host at the DNS level, but the pin is silently skipped, and the connection is verified against an ordinary CA-issued certificate instead.

OkHostnameVerifier already treats both spellings as equivalent for exactly this reason (it normalizes both hostname and pattern to absolute form before comparing). CertificatePinner never got the same treatment.

Fix: strip a single trailing dot from hostname at the top of matchesHostname, before the wildcard/exact-match dispatch. All three branches (**., *., and exact) already reference the same hostname identifier, so this one change covers them uniformly. pattern is left untouched -- it is never legitimately going to carry a trailing dot in practice, and the reported issue is specifically about the hostname side.

Added testMatchesHostnameWithTrailingDot to CertificatePinnerKotlinTest, covering both the exact-match and wildcard branches directly on Pin.matchesHostname, plus the reporter's own findMatchingPins() shape.

Verified with a decisive negative control: reverting only the source fix (keeping the new test) reproduces the exact reported behavior -- the test fails with "expected: <true> but was: <false>" on the trailing-dot assertion, confirming the old code silently skips the pin for the dotted hostname.
