### PR TITLE
Remove BUG-BOUNTY.md

### DIFF
--- a/BUG-BOUNTY.md
+++ b/BUG-BOUNTY.md
@@ -1,9 +1,1 @@
-Serious about security
-======================
 
-Square recognizes the important contributions the security research community
-can make. We therefore encourage reporting security issues with the code
-contained in this repository.
-
-If you believe you have discovered a security vulnerability, please follow the
-guidelines at https://bugcrowd.com/engagements/blockopensource.


### PR DESCRIPTION
Removes BUG-BOUNTY.md, which I originally added in #9081. The current guidance points to Block's bug bounty program and should be removed from this fork.
